### PR TITLE
fix(Result): Result.recoverWhen should execute the predicate before executing the lambda

### DIFF
--- a/source/result.js
+++ b/source/result.js
@@ -183,8 +183,9 @@ Object.assign(Error.prototype, {
 
   recoverWhen(predicate, λ) {
     return Ok(this.error)
-    .map(λ)
-    .filter(predicate);
+    .filter(predicate)
+    .mapError(constant(this.error))
+    .map(λ);
   },
 
   merge() {

--- a/test/result-test.js
+++ b/test/result-test.js
@@ -307,6 +307,21 @@ describe('The Result type', () => {
 
         expect(transformed.merge()).to.equal(value);
       });
+
+      it('should not call the lambda if the predicate evaluates to false', () => {
+        let lambdaCalled = false;
+
+        const value = 10;
+
+        const error = Error(value);
+
+        const transformed = error.recoverWhen(constant(false), () => {
+          lambdaCalled = true;
+        });
+
+        expect(lambdaCalled).to.equal(false);
+        expect(transformed.merge()).to.equal(value);
+      });
     });
 
     describe('flatMap(λ)', () => {


### PR DESCRIPTION
Fuxes #7