### PR TITLE
fix(Result): Make sure passing rejected promises to Result doesn't result in the promises being marked as uncaught

### DIFF
--- a/source/return-this.js
+++ b/source/return-this.js
@@ -1,13 +1,26 @@
+async function absorbRejectedPromises(value) {
+  try {
+    await value;
+  } catch (_) {
+    // Nothing to do here.
+  }
+}
+
 module.exports = {
   nullary: function nullaryReturnThis() {
     return this;
   },
 
   unary: function unaryReturnThis(unusedArgument) {
+    absorbRejectedPromises(unusedArgument);
+
     return this;
   },
 
   binary: function unaryReturnThis(unusedArgument, secondUnusedArgument) {
+    absorbRejectedPromises(unusedArgument);
+    absorbRejectedPromises(secondUnusedArgument);
+
     return this;
   }
 };

--- a/test/result-test.js
+++ b/test/result-test.js
@@ -12,7 +12,7 @@ const increment      = n => n + 1;
 const asyncIncrement = async n => n + 1;
 
 process.on('unhandledRejection', (reason, promise) => {
-  console.log(reason);
+  console.log(`Uncaught error: ${reason}`);
 });
 
 describe('The Result type', () => {


### PR DESCRIPTION
The tests output `5` without this change due to the way a unit test is implemented.